### PR TITLE
Added Marlin-compatible script for use with a Zero Cube

### DIFF
--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -3,7 +3,7 @@
 ;
 ; !! Intended for Marlin 2.xx users, but may work for other firmware with slight adjustments
 ;
-; Link to (3D printable) Zeroing Cube used in this script: https://www.thingiverse.com/thing:4809964
+; Link to (3D printable) Zeroing Cube used in this script: https://www.thingiverse.com/thing:5029043
 
 ; Start with end mill roughly in center of cube, with bit slightly (~3mm-10mm) above cube surface.
 ; Bit must extend BELOW the top of the zero cube walls (so it touches them on a lateral move)

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -13,13 +13,13 @@
 
 ; Set user-defined variables
 ; !! All measurements are in mm (not in Luddite units, you savages)
-%WIDEST_BIT_YOU_OWN = 30        ; Diameter of the widest bit you'll ever use with this script
-%CUBE_HEIGHT = 7	          ; Height of main section of Zero Cube
-%CUBE_WALL_HEIGHT = 12	    ; How high the XY wall section extends above the base
-%CUBE_WALL_THICKNESS = 6	  ; How wide (laterally thick) are the XY wall sections
+%WIDEST_BIT_YOU_OWN = 15        ; Diameter of the widest bit you'll ever use with this script
+%CUBE_HEIGHT = 6.2	          ; Height of main section of Zero Cube
+%CUBE_WALL_HEIGHT = 13	    ; How high the XY wall section extends above the base
+%CUBE_WALL_THICKNESS = 6.5	  ; How wide (laterally thick) are the XY wall sections
 %PROBE_XY_DISTANCE = 150         ; Max distance for a probe motion (script will fail if bit further from wall than this)
-%PROBE_FEEDRATE = 40      ; mm/min
-%Z_FINAL = 10	                  ; Desired height of bit above CUBE_WALL_HEIGHT after probing is finished
+%PROBE_FEEDRATE = 30      ; mm/min
+%Z_FINAL = 25.4	                  ; Desired height of bit from bed after probing is finished
 
 %UNITS=modal.units
 %DISTANCE=modal.distance
@@ -68,8 +68,7 @@ G92 Y0
 
 ; Place bit center at final X0 Y0
 G90	; Absolute positioning
-%FINAL_MOVE = CUBE_HEIGHT + CUBE_WALL_HEIGHT + Z_FINAL
-G0 X0 Y0 Z[FINAL_MOVE]
+G0 X0 Y0 Z[Z_FINAL]
 
 M211 S1 ; Re-enable software endstops
 [UNITS] [DISTANCE] ; Restore unit and distance modal state

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -13,87 +13,65 @@
 
 ; Set user-defined variables
 ; !! All measurements are in mm (not in Luddite units, you savages)
-%WIDEST_BIT_YOU_OWN = 20        ; Diameter of the widest bit you'll ever use with this script
-%ZERO_CUBE_HEIGHT = 8	          ; Height of main section of Zero Cube
-%ZERO_CUBE_WALL_HEIGHT = 12	    ; How high the XY wall section extends above %ZERO_CUBE_HEIGHT (ie: NOT the total height)
-%ZERO_CUBE_WALL_THICKNESS = 5	  ; How wide (laterally thick) are the XY wall sections which extend above %ZERO_CUBE_HEIGHT
-%PROBE_XY_DISTANCE = 40         ; Max distance for a probe motion (script will fail if bit further from wall than this)
-%PROBE_FEEDRATE_FAST = 200      ; mm/min
-%PROBE_FEEDRATE_SLOW = 100      ; mm/min
-%PROBE_RETRACT = 20             ; Distance of retract before probing next axis
-%Z_FINAL = 10	                  ; Desired height of bit above ZERO_CUBE_WALL_HEIGHT after probing is finished
-
+%WIDEST_BIT_YOU_OWN = 30        ; Diameter of the widest bit you'll ever use with this script
+%CUBE_HEIGHT = 7	          ; Height of main section of Zero Cube
+%CUBE_WALL_HEIGHT = 12	    ; How high the XY wall section extends above the base
+%CUBE_WALL_THICKNESS = 6	  ; How wide (laterally thick) are the XY wall sections
+%PROBE_XY_DISTANCE = 150         ; Max distance for a probe motion (script will fail if bit further from wall than this)
+%PROBE_FEEDRATE = 40      ; mm/min
+%Z_FINAL = 10	                  ; Desired height of bit above CUBE_WALL_HEIGHT after probing is finished
 
 %UNITS=modal.units
 %DISTANCE=modal.distance
 
-
 G91     ; Relative positioning
 G21     ; Use millimeters
 G54     ; Switch to Work Coordinate Set 1 (as opposed to Machine Coords, which should not be altered after homing)
-
-; Make sure initial coordinates remain positive for easier math
-G92 X[PROBE_XY_DISTANCE * 2 + ZERO_CUBE_WALL_THICKNESS] Y[PROBE_XY_DISTANCE * 2 + ZERO_CUBE_WALL_THICKNESS] Z[ZERO_CUBE_WALL_HEIGHT]
+M211 S0 ; Disable software endstops
 
 ; Probe Z
-G38.2 Z-[ZERO_CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE_FAST]
-G0 Z2 ; Retract 2mm
-G38.2 Z-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
-G92 Z[ZERO_CUBE_HEIGHT]
+G38.2 Z-[CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE/2]
+G92 Z[CUBE_HEIGHT]
 G0 Z3	; Raise Z
-; A dwell time of one second to make sure the planner queue is empty
-G4 P1
 
 ; Probe X to find side of bit
-G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
+G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
+G92 X0
+%X1 = posx
 G0 X2 ; Retract 2mm
-G38.2 X-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
-%X_LEFT = posx
-G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
-G0 X-[WIDEST_BIT_YOU_OWN + ZERO_CUBE_WALL_THICKNESS + 10]	; Move to other side of wall
-G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
+M117 Determining bit width
+G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
+%X_MOVE = WIDEST_BIT_YOU_OWN + CUBE_WALL_THICKNESS + 10
+G0 X-[X_MOVE]	; Move to other side of wall
+G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
 
 ; Probe X to find other side of bit
-G38.2 X[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
-G0 X-2 ; Retract 2mm
-G38.2 X4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
-%X_RIGHT = posx
-%X_DIFFERENCE = X_LEFT - X_RIGHT + ZERO_CUBE_WALL_THICKNESS
-G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
-G0 X[X_DIFFERENCE / 2] ; Move to where the center of the bit is at zero (the right edge of the left wall)
+G38.2 X[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
+%X2 = posx
+%BIT_DIAMETER = X1 - X2 - CUBE_WALL_THICKNESS
+%BIT_RADIUS = BIT_DIAMETER / 2
+M117 Your bit's Diameter is: [BIT_DIAMETER], Radius: [BIT_RADIUS]
+G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
+M117 Moving to new X0
+%NEW_ZERO = CUBE_WALL_THICKNESS + BIT_RADIUS
+G0 X[NEW_ZERO]
 G92 X0
-G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
-G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
 
-; A dwell time of one second to make sure the planner queue is empty
-G4 P1
+G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
+G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
 
 ; Probe Y to find side of bit
-G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
-G0 Y2 ; Retract 2mm
-G38.2 Y-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
-%Y_TOP = posy
-G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
-G0 Y-[WIDEST_BIT_YOU_OWN + ZERO_CUBE_WALL_THICKNESS + 10]	; Move to other side of wall
-G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
-
-; Probe Y to find other side of bit
-G38.2 Y[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
-G0 Y-2 ; Retract 2mm
-G38.2 Y4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
-%Y_BOTTOM = posy
-%Y_DIFFERENCE = Y_TOP - Y_BOTTOM + ZERO_CUBE_WALL_THICKNESS
-G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
-G0 Y[Y_DIFFERENCE / 2] ; Move to where the center of the bit is at zero (the top edge of the lower wall)
+G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
+G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
+G0 Y-[BIT_RADIUS]
 G92 Y0
 
 ; Place bit center at final X0 Y0
 G90	; Absolute positioning
-G0 X0 Y0 Z[ZERO_CUBE_HEIGHT + ZERO_CUBE_WALL_HEIGHT + Z_FINAL]
+%FINAL_MOVE = CUBE_HEIGHT + CUBE_WALL_HEIGHT + Z_FINAL
+G0 X0 Y0 Z[FINAL_MOVE]
 
-; A dwell time of one second to make sure the planner queue is empty
-G4 P1
-
+M211 S1 ; Re-enable software endstops
 [UNITS] [DISTANCE] ; Restore unit and distance modal state
 
-; All finished and ready to carve!
+M117 All finished!

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -1,0 +1,99 @@
+; This script enables the automation of zeroing out new bits to a workpiece using a conductive Zeroing Cube,
+; while also automatically measuring and accounting for bit radius.
+;
+; !! Intended for Marlin 2.xx users, but may work for other firmware with slight adjustments
+;
+; Link to (3D printable) Zeroing Cube used in this script: https://www.thingiverse.com/thing:4809964
+
+; Start with end mill roughly in center of cube, with bit slightly (~3mm-10mm) above cube surface.
+; Bit must extend BELOW the top of the zero cube walls (so it touches them on a lateral move)
+
+; Wait until the planner queue is empty
+%wait
+
+; Set user-defined variables
+; !! All measurements are in mm (not in Luddite units, you savages)
+%WIDEST_BIT_YOU_OWN = 20        ; Diameter of the widest bit you'll ever use with this script
+%ZERO_CUBE_HEIGHT = 8	          ; Height of main section of Zero Cube
+%ZERO_CUBE_WALL_HEIGHT = 12	    ; How high the XY wall section extends above %ZERO_CUBE_HEIGHT (ie: NOT the total height)
+%ZERO_CUBE_WALL_THICKNESS = 5	  ; How wide (laterally thick) are the XY wall sections which extend above %ZERO_CUBE_HEIGHT
+%PROBE_XY_DISTANCE = 40         ; Max distance for a probe motion (script will fail if bit further from wall than this)
+%PROBE_FEEDRATE_FAST = 200      ; mm/min
+%PROBE_FEEDRATE_SLOW = 100      ; mm/min
+%PROBE_RETRACT = 20             ; Distance of retract before probing next axis
+%Z_FINAL = 10	                  ; Desired height of bit above ZERO_CUBE_WALL_HEIGHT after probing is finished
+
+
+%UNITS=modal.units
+%DISTANCE=modal.distance
+
+
+G91     ; Relative positioning
+G21     ; Use millimeters
+G54     ; Switch to Work Coordinate Set 1 (as opposed to Machine Coords, which should not be altered after homing)
+
+; Make sure initial coordinates remain positive for easier math
+G92 X[PROBE_XY_DISTANCE * 2 + ZERO_CUBE_WALL_THICKNESS] Y[PROBE_XY_DISTANCE * 2 + ZERO_CUBE_WALL_THICKNESS] Z[ZERO_CUBE_WALL_HEIGHT]
+
+; Probe Z
+G38.2 Z-[ZERO_CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE_FAST]
+G0 Z2 ; Retract 2mm
+G38.2 Z-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
+G92 Z[ZERO_CUBE_HEIGHT]
+G0 Z3	; Raise Z
+; A dwell time of one second to make sure the planner queue is empty
+G4 P1
+
+; Probe X to find side of bit
+G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
+G0 X2 ; Retract 2mm
+G38.2 X-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
+%X_LEFT = posx
+G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
+G0 X-[WIDEST_BIT_YOU_OWN + ZERO_CUBE_WALL_THICKNESS + 10]	; Move to other side of wall
+G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
+
+; Probe X to find other side of bit
+G38.2 X[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
+G0 X-2 ; Retract 2mm
+G38.2 X4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
+%X_RIGHT = posx
+%X_DIFFERENCE = X_LEFT - X_RIGHT + ZERO_CUBE_WALL_THICKNESS
+G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
+G0 X[X_DIFFERENCE / 2] ; Move to where the center of the bit is at zero (the right edge of the left wall)
+G92 X0
+G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
+G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
+
+; A dwell time of one second to make sure the planner queue is empty
+G4 P1
+
+; Probe Y to find side of bit
+G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
+G0 Y2 ; Retract 2mm
+G38.2 Y-4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
+%Y_TOP = posy
+G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
+G0 Y-[WIDEST_BIT_YOU_OWN + ZERO_CUBE_WALL_THICKNESS + 10]	; Move to other side of wall
+G0 -Z[ZERO_CUBE_WALL_HEIGHT]	; Drop Z below wall
+
+; Probe Y to find other side of bit
+G38.2 Y[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE_FAST]
+G0 Y-2 ; Retract 2mm
+G38.2 Y4 F[PROBE_FEEDRATE_SLOW] ; Slow Probe
+%Y_BOTTOM = posy
+%Y_DIFFERENCE = Y_TOP - Y_BOTTOM + ZERO_CUBE_WALL_THICKNESS
+G0 Z[ZERO_CUBE_WALL_HEIGHT]	; Retract Z above wall
+G0 Y[Y_DIFFERENCE / 2] ; Move to where the center of the bit is at zero (the top edge of the lower wall)
+G92 Y0
+
+; Place bit center at final X0 Y0
+G90	; Absolute positioning
+G0 X0 Y0 Z[ZERO_CUBE_HEIGHT + ZERO_CUBE_WALL_HEIGHT + Z_FINAL]
+
+; A dwell time of one second to make sure the planner queue is empty
+G4 P1
+
+[UNITS] [DISTANCE] ; Restore unit and distance modal state
+
+; All finished and ready to carve!

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -13,13 +13,13 @@
 
 ; Set user-defined variables
 ; !! All measurements are in mm (not in Luddite units, you savages)
-%WIDEST_BIT_YOU_OWN = 15        ; Diameter of the widest bit you'll ever use with this script
-%CUBE_HEIGHT = 6.2	          ; Height of main section of Zero Cube
-%CUBE_WALL_HEIGHT = 13	    ; How high the XY wall section extends above the base
-%CUBE_WALL_THICKNESS = 6.5	  ; How wide (laterally thick) are the XY wall sections
-%PROBE_XY_DISTANCE = 150         ; Max distance for a probe motion (script will fail if bit further from wall than this)
-%PROBE_FEEDRATE = 30      ; mm/min
-%Z_FINAL = 25.4	                  ; Desired height of bit from bed after probing is finished
+%WIDEST_BIT_YOU_OWN = 8 ; Diameter of the widest bit you'll ever use with this script
+%CUBE_HEIGHT = 6.2 ; Height of main section of Zero Cube
+%CUBE_WALL_HEIGHT = 16 ; How high the XY wall section extends above the base
+%CUBE_WALL_THICKNESS = 6.5 ; How wide (laterally thick) are the XY wall sections
+%PROBE_XY_DISTANCE = 50 ; Max distance for a probe motion (script will fail if bit further from wall than this)
+%PROBE_FEEDRATE = 600 ; mm/min
+%Z_FINAL = 25.4 ; Desired height of bit from bed after probing is finished (25.4 is one inch)
 
 %UNITS=modal.units
 %DISTANCE=modal.distance
@@ -30,46 +30,47 @@ G54     ; Switch to Work Coordinate Set 1 (as opposed to Machine Coords, which s
 M211 S0 ; Disable software endstops
 
 ; Probe Z
-G38.2 Z-[CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE/2]
-G92 Z[CUBE_HEIGHT]
-G0 Z2	; Raise Z
+G38.2 Z-[CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE/2] (Probing Z)
+G92 Z[CUBE_HEIGHT] (Setting Z0)
+G0 Z2 (Raising Z)
 
 ; Probe X to find side of bit
-G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
-G92 X0 ; Temporary zero for easy math
+G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE] (Probing X)
+G92 X0 (Temporary zero for easy math)
 %X1 = posx
-G0 X2 ; Retract 2mm
+G0 X2 (Retracting 2mm)
 M117 Determining bit width
-G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
-%X_MOVE = WIDEST_BIT_YOU_OWN + CUBE_WALL_THICKNESS + 3
-G0 X-[X_MOVE]	; Move to other side of wall
-G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
+G0 Z[CUBE_WALL_HEIGHT]	(Retract Z above wall)
+%X_MOVE = Number(WIDEST_BIT_YOU_OWN) + Number(CUBE_WALL_THICKNESS) + 5
+G0 X-[X_MOVE] (Move to other side of wall)
+G0 Z-[CUBE_WALL_HEIGHT] (Drop Z below wall)
 
 ; Probe X to find other side of bit
-G38.2 X[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
+G38.2 X[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE] (Probe X to find other side of bit)
 %X2 = posx
-%BIT_DIAMETER = X1 - X2 - CUBE_WALL_THICKNESS
+%BIT_DIAMETER = Math.abs(X1 - X2 - CUBE_WALL_THICKNESS)
 %BIT_RADIUS = BIT_DIAMETER / 2
 M117 Your bit's Diameter is: [BIT_DIAMETER], Radius: [BIT_RADIUS]
-G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
-M117 Moving to new X0
-%NEW_ZERO = CUBE_WALL_THICKNESS + BIT_RADIUS
-G92 X-[NEW_ZERO]
+G0 Z[CUBE_WALL_HEIGHT] (Retract Z above wall)
+M117 Setting new X0
+%NEW_ZERO = Number(CUBE_WALL_THICKNESS) + Number(BIT_RADIUS)
+G92 X-[NEW_ZERO] (New X0)
 
-G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
-G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
+%SAFE_X = Number(WIDEST_BIT_YOU_OWN) + Number(CUBE_WALL_THICKNESS) + 5
+G0 X[SAFE_X] (Position X for Y probing)
+G0 Z-[CUBE_WALL_HEIGHT] (Drop Z below wall)
 
 ; Probe Y to find side of bit
-G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
-G92 Y[BIT_RADIUS]
-G0 Y2
-G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
+G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE] (Probe Y to find side of bit)
+G92 Y[BIT_RADIUS] (Set new Y0)
+G0 Y2 (Back off Y)
+G0 Z[CUBE_WALL_HEIGHT] (Retract Z above wall)
 
 ; Place bit center at final X0 Y0
 G90	; Absolute positioning
-G0 X0 Y0 Z[Z_FINAL]
+G0 X0 Y0 Z[Z_FINAL] (Place bit center at final X0 Y0)
 
-M211 S1 ; Re-enable software endstops
-[UNITS] [DISTANCE] ; Restore unit and distance modal state
+M211 S1 (Re-enable software endstops)
+[UNITS] [DISTANCE] (Restore unit and distance modal state)
 
 M117 All finished!

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -54,7 +54,7 @@ M117 Your bit's Diameter is: [BIT_DIAMETER], Radius: [BIT_RADIUS]
 G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
 M117 Moving to new X0
 %NEW_ZERO = CUBE_WALL_THICKNESS + BIT_RADIUS
-G92 X[NEW_ZERO]
+G92 X-[NEW_ZERO]
 
 G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
 G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall

--- a/Marlin_Work_Zero_Using_Cube
+++ b/Marlin_Work_Zero_Using_Cube
@@ -32,16 +32,16 @@ M211 S0 ; Disable software endstops
 ; Probe Z
 G38.2 Z-[CUBE_WALL_HEIGHT] F[PROBE_FEEDRATE/2]
 G92 Z[CUBE_HEIGHT]
-G0 Z3	; Raise Z
+G0 Z2	; Raise Z
 
 ; Probe X to find side of bit
 G38.2 X-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
-G92 X0
+G92 X0 ; Temporary zero for easy math
 %X1 = posx
 G0 X2 ; Retract 2mm
 M117 Determining bit width
 G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
-%X_MOVE = WIDEST_BIT_YOU_OWN + CUBE_WALL_THICKNESS + 10
+%X_MOVE = WIDEST_BIT_YOU_OWN + CUBE_WALL_THICKNESS + 3
 G0 X-[X_MOVE]	; Move to other side of wall
 G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
 
@@ -54,17 +54,16 @@ M117 Your bit's Diameter is: [BIT_DIAMETER], Radius: [BIT_RADIUS]
 G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
 M117 Moving to new X0
 %NEW_ZERO = CUBE_WALL_THICKNESS + BIT_RADIUS
-G0 X[NEW_ZERO]
-G92 X0
+G92 X[NEW_ZERO]
 
 G0 X[WIDEST_BIT_YOU_OWN] ; Position X for Y probing
 G0 Z-[CUBE_WALL_HEIGHT]	; Drop Z below wall
 
 ; Probe Y to find side of bit
 G38.2 Y-[PROBE_XY_DISTANCE] F[PROBE_FEEDRATE]
+G92 Y[BIT_RADIUS]
+G0 Y2
 G0 Z[CUBE_WALL_HEIGHT]	; Retract Z above wall
-G0 Y-[BIT_RADIUS]
-G92 Y0
 
 ; Place bit center at final X0 Y0
 G90	; Absolute positioning


### PR DESCRIPTION
This script enables the automation of zeroing out new bits to a workpiece using a conductive Zeroing Cube (link to matching 3d printable cube included), while also automatically measuring and accounting for bit radius.

Intended for Marlin 2.xx users, but will likely work with other firmware

Fully documented